### PR TITLE
bug fix of double click node show dss plot and tables

### DIFF
--- a/jdiagram/src/main/java/gov/ca/dwr/jdiagram/views/SchematicBase.java
+++ b/jdiagram/src/main/java/gov/ca/dwr/jdiagram/views/SchematicBase.java
@@ -267,6 +267,7 @@ public abstract class SchematicBase extends ViewPart {
 			} 
 
 			public void showDSS(String name){
+				name=name.toLowerCase();
 				final Vector<DataContainer> data=new Vector<DataContainer>();
 				for (int i=0; i<4; i++){
 					if (DssPluginCore.allSchematicVariableData[i].containsKey(name)){


### PR DESCRIPTION
When a user double clicks a node on schematic, if dss files are already loaded in the DSS perspectvie, dss plot and table/monthly table should be popped up and display the dss data. The fix makes this action work.  