### PR TITLE
Add Read the Docs config files

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.13"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,39 @@
+# Configuration file for the Sphinx documentation builder.
+
+# -- Project information
+
+project = "wrims-gui"
+copyright = "2026, CA Department of Water Resources"
+author = "Zachary Roy"
+
+release = "0.1"
+version = "0.1.0"
+
+# -- General configuration
+
+extensions = [
+    "sphinx.ext.duration",
+    "sphinx.ext.doctest",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.intersphinx",
+    "myst_parser",
+]
+
+intersphinx_mapping = {
+    "wrims-docs": ("https://www.sphinx-doc.org/en/master/", None),
+    "wrims-gui": ("https://www.sphinx-doc.org/en/master/", None),
+    "wresl": ("https://www.sphinx-doc.org/en/master/", None),
+}
+intersphinx_disabled_reftypes = ["*"]
+
+templates_path = ["_templates"]
+
+# -- Options for HTML output
+
+html_theme = "sphinx_rtd_theme"
+
+# -- Options for EPUB output
+epub_show_urls = "footnote"
+
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,8 @@
+WRIMS GUI
+============
+
+.. note::
+    This documentation is under active development.
+
+Contents
+--------

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx==7.1.2
+sphinx-rtd-theme==1.3.0rc1
+myst-parser==3.0.1


### PR DESCRIPTION
Adds basic config files to establish the Read the Docs project for WRIMS GUI. This project will be classified as a "subproject" to the wrims-docs project. Other subprojects will be established for WRIMS Engine and WRESL+.

The added files are stubs, and will be populated by later pull requests. The stubs allow for configuration to proceed on the Read the Docs platform.
