### PR TITLE
improve error handling and delay on socket startup

### DIFF
--- a/wrims-ide/src/main/java/gov/ca/water/wrims/gui/ide/debugger/launcher/WPPLaunchDelegate.java
+++ b/wrims-ide/src/main/java/gov/ca/water/wrims/gui/ide/debugger/launcher/WPPLaunchDelegate.java
@@ -179,10 +179,12 @@ public class WPPLaunchDelegate extends LaunchConfigurationDelegate {
 				DebugCorePlugin.debugSet.reset();
 				Process process = Runtime.getRuntime().exec(WPPSettings.WRIMS_ENGINE_BAT);
 				IProcess p = DebugPlugin.newProcess(launch, process, "DebugWPP");
-				IDebugTarget target = new WPPDebugTarget(launch, p, requestPort, eventPort);
-				launch.addDebugTarget(target);
-				process.waitFor();
-				terminateCode=process.exitValue();
+				try(WPPDebugTarget target = new WPPDebugTarget(launch, p, requestPort, eventPort)) {
+					target.getStart();
+					launch.addDebugTarget(target);
+					process.waitFor();
+					terminateCode = process.exitValue();
+				}
 			}else{
 				Process process = Runtime.getRuntime().exec(WPPSettings.WRIMS_ENGINE_BAT);
 				IProcess p = DebugPlugin.newProcess(launch, process, "RunWPP");
@@ -227,12 +229,14 @@ public class WPPLaunchDelegate extends LaunchConfigurationDelegate {
 					DebugCorePlugin.debugSet.reset();
 					Process process = Runtime.getRuntime().exec(WPPSettings.WRIMS_ENGINE_BAT);
 					IProcess p = DebugPlugin.newProcess(launch, process, "DebugWPP");
-					IDebugTarget target = new WPPDebugTarget(launch, p, requestPort, eventPort);
-					launch.addDebugTarget(target);
-					process.waitFor();
-					terminateCode=process.exitValue();
-					launch.removeDebugTarget(target);
-					process.destroy();
+					try(WPPDebugTarget target = new WPPDebugTarget(launch, p, requestPort, eventPort)) {
+						target.getStart();
+						launch.addDebugTarget(target);
+						process.waitFor();
+						terminateCode = process.exitValue();
+						launch.removeDebugTarget(target);
+						process.destroy();
+					}
 				}else{
 					Process process = Runtime.getRuntime().exec(WPPSettings.WRIMS_ENGINE_BAT);
 					IProcess p = DebugPlugin.newProcess(launch, process, "RunWPP");

--- a/wrims-ide/src/main/java/gov/ca/water/wrims/gui/ide/debugger/model/WPPDebugTarget.java
+++ b/wrims-ide/src/main/java/gov/ca/water/wrims/gui/ide/debugger/model/WPPDebugTarget.java
@@ -30,10 +30,10 @@ import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.lang.reflect.InvocationTargetException;
 import java.net.Socket;
-import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Vector;
+import java.util.concurrent.CountDownLatch;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarkerDelta;
 import org.eclipse.core.resources.ResourcesPlugin;
@@ -76,7 +76,8 @@ import org.eclipse.ui.texteditor.ITextEditor;
 /**
  * WPP Debug Target
  */
-public class WPPDebugTarget extends WPPDebugElement implements IDebugTarget, IBreakpointManagerListener, IWPPEventListener {
+public class WPPDebugTarget extends WPPDebugElement
+	implements IDebugTarget, IBreakpointManagerListener, IWPPEventListener, AutoCloseable {
 	
 	// associated system process (VM)
 	private IProcess fProcess;
@@ -105,14 +106,16 @@ public class WPPDebugTarget extends WPPDebugElement implements IDebugTarget, IBr
 	private IWorkbenchPart fPart;
 	private IPartListener fPartListener;
 	private IPartListener2 fPartListener2;
-	public ArrayList<String> allVGLoadedViewNames=new ArrayList<String>(); 
+	public ArrayList<String> allVGLoadedViewNames=new ArrayList<String>();
 	private ArrayList<String> dataAvaialbeViewNames = new ArrayList<String>();
 	
 	// event dispatch job
 	private EventDispatchJob fEventDispatch;
 	// event listeners
 	private Vector fEventListeners = new Vector();
-	
+	private final CountDownLatch initialized = new CountDownLatch(1);
+	private volatile Exception initializationFailure;
+
 	/**
 	 * Listens to events from the WPP VM and fires corresponding 
 	 * debug events.
@@ -184,92 +187,68 @@ public class WPPDebugTarget extends WPPDebugElement implements IDebugTarget, IBr
 	public WPPDebugTarget(ILaunch launch, IProcess process, int requestPort, int eventPort) throws CoreException {
 		super(null);
 		DebugCorePlugin.target=this;
-		fLaunch = launch;
-		fProcess = process;
-		addEventListener(this);
 		try {
+			fLaunch = launch;
+			fProcess = process;
+			addEventListener(this);
 			// give interpreter a chance to start
-			try {
-				Thread.sleep(3000);
-			} catch (InterruptedException e) {
-			}
+			Thread.sleep(3000);
 			fRequestSocket = new Socket("localhost", requestPort);
 			fEventSocket = new Socket("localhost", eventPort);
 			fRequestWriter = new PrintWriter(fRequestSocket.getOutputStream());
 			fRequestReader = new BufferedReader(new InputStreamReader(fRequestSocket.getInputStream()));
 			fEventReader = new BufferedReader(new InputStreamReader(fEventSocket.getInputStream()));
-		} catch (UnknownHostException e) {
+			fThread = new WPPThread(this);
+			fThreads = new IThread[] {fThread};
+			fEventDispatch = new EventDispatchJob();
+			fEventDispatch.schedule();
+			IBreakpointManager breakpointManager = getBreakpointManager();
+			breakpointManager.addBreakpointListener(this);
+			breakpointManager.addBreakpointManagerListener(this);
+			installPartListener();
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			initializationFailure = e;
+			requestFailed("Debug target interrupted", e);
+		} catch (IOException | RuntimeException e) {
+			initializationFailure = e;
 			requestFailed("Unable to connect to WPP VM", e);
-		} catch (IOException e) {
-			requestFailed("Unable to connect to WPP VM", e);
+		} finally {
+			initialized.countDown();
 		}
-		fThread = new WPPThread(this);
-		fThreads = new IThread[] {fThread};
-		fEventDispatch = new EventDispatchJob();
-		fEventDispatch.schedule();
-		
-		IBreakpointManager breakpointManager = getBreakpointManager();
-        breakpointManager.addBreakpointListener(this);
-		breakpointManager.addBreakpointManagerListener(this);
-		
-		//installDeferredBreakpoints();
-		
-		installPartListener();
-		
-		getStart();
-		//System.out.println(data);
-		//data=sendRequest("variables:s_shsta#s_folsm");
-		//System.out.println(data);
-		
-		
-		/*
-		if (fTextEditor!=null) ((ITextEditor)fTextEditor).resetHighlightRange();
-		data=sendRequest("resume");
-		System.out.println(data);
-		
+	}
+
+	private boolean awaitInitialized() throws DebugException {
 		try {
-			Thread.sleep(5000);
+			initialized.await();
 		} catch (InterruptedException e) {
-			WPPException.handleException(e);
+			Thread.currentThread().interrupt();
+			requestFailed("Interrupted while waiting for debug target initialization", e);
 		}
-		
-		data=sendRequest("step");
-		System.out.println(data);
-		
-		if (fTextEditor!=null) ((ITextEditor)fTextEditor).resetHighlightRange();
-		data=sendRequest("resume");
-		System.out.println(data);
-		
-		try {
-			Thread.sleep(5000);
-		} catch (InterruptedException e) {
-			WPPException.handleException(e);
+
+        return initializationFailure == null;
+    }
+
+	@Override
+	public void close() throws Exception {
+		if (fProcess != null) {
+			fProcess.terminate();
 		}
-		
-		data=sendRequest("year:10001");
-		System.out.println(data);
-		
-		if (fTextEditor!=null) ((ITextEditor)fTextEditor).resetHighlightRange();
-		data=sendRequest("resume");
-		System.out.println(data);
-		
-		try {
-			Thread.sleep(5000);
-		} catch (InterruptedException e) {
-			WPPException.handleException(e);
+		if (fEventDispatch != null) {
+			fEventDispatch.cancel();
 		}
-		
-		
-		fProcess.terminate();
-		workbench.getDisplay().asyncExec(new Runnable(){
-			public void run(){
-				IWorkbenchWindow window=workbench.getActiveWorkbenchWindow();
-				if (window !=null){
-					window.getActivePage().removePartListener(fPartListener);
-				}
-			}
-		});
-		*/
+		if (fRequestSocket != null) {
+			fRequestSocket.close();
+		}
+		if (fEventSocket != null) {
+			fEventSocket.close();
+		}
+		if (fRequestWriter != null) {
+			fRequestWriter.close();
+		}
+		if (fRequestReader != null) {
+			fRequestReader.close();
+		}
 	}
 	
 	public void getStart() {
@@ -711,6 +690,8 @@ public class WPPDebugTarget extends WPPDebugElement implements IDebugTarget, IBr
 	 */
 	@Override
 	public String sendRequest(String request) throws DebugException {
+		if(!awaitInitialized()) return null;
+		if (fRequestSocket == null) return null;
 		synchronized (fRequestSocket) {
 			fRequestWriter.println(request);
 			fRequestWriter.flush();

--- a/wrims-ide/src/main/java/gov/ca/water/wrims/gui/ide/debugger/view/WPPExceptionView.java
+++ b/wrims-ide/src/main/java/gov/ca/water/wrims/gui/ide/debugger/view/WPPExceptionView.java
@@ -1,5 +1,7 @@
 package gov.ca.water.wrims.gui.ide.debugger.view;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.List;
@@ -8,6 +10,7 @@ import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.part.ViewPart;
 
 public class WPPExceptionView extends ViewPart implements ISelectionListener{
+	private static final Logger LOGGER = Logger.getLogger(WPPExceptionView.class.getName());
 	private List list;
 	
 	public WPPExceptionView(){
@@ -24,16 +27,24 @@ public class WPPExceptionView extends ViewPart implements ISelectionListener{
 	public void createPartControl(Composite parent) {
 		list=new List(parent,1);
 	}
-	
-	public void addException(Exception e){
-		String message = e.getMessage();
-		if(message!=null)
-		{
-			list.add(e.getMessage());
-		}
-		else
-		{
-			list.add("Unknown Exception");
+
+	public void addException(Exception e) {
+		LOGGER.log(Level.WARNING, "Exception caught", e);
+		Throwable current = e;
+		boolean first = true;
+
+		while (current != null) {
+			String message = current.getMessage();
+			String prefix = first ? "" : "\tCaused by:";
+
+			if (message != null) {
+				list.add(prefix + message);
+			} else {
+				list.add(prefix + "Unknown exception: " + current.getClass().getName());
+			}
+
+			first = false;
+			current = current.getCause();
 		}
 	}
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Notes for Reviewers
Please consider the following when reviewing this PR:
- **Correctness:** Does the code do what it claims? Are edge cases handled appropriately?
- **Clarity:** Is the code readable, maintainable and aligned with **SOLID** design principles?
- **Impact:** Will this change affect other parts of the system? Any potential regressions?
- **Testing:** Are the test cases sufficient and appropriate? Are there gaps in coverage?
- **Documentation:** Does this require updates to code comments, README, or other docs?

## Description
Updates the WPPDebugTarget to handle the case of one thread accessing the globally set instance to send instructions before the socket is opened. The underlying issue from opening the socket is lost because WPPExceptionView only reports the top most error and didn't log the stack trace. The view was enhanced to add all exception messages and log the stack trace for better debugging. Likely the root cause was the target port already being open. The other issue was that the resources opened by the debug target were never getting closed. Updated to auto-close sockets etc when the target falls out of scope.

## Motivation and Context
Addresses #179 

## How Has This Been Tested?
Tested by running debugger as described in the attached issue. Could not reproduce the issue and the debugger worked as expected, however when modifying the code to force the error and identifying the global state, it was identified that more robust error handling was needed.

## Screenshots (if appropriate)
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change
- [ ] New tests (new unit tests, test scenarios, or test case documentation)
- [ ] Triggers regression testing (change affects downstream modules and will require regression testing)
<!--- see how your change affects other areas of the code, etc. -->
- [ ] Other (include a description)
