### PR TITLE
Fix report y-axis labels

### DIFF
--- a/wrims-ide/src/main/java/gov/ca/water/wrims/gui/ide/reporttool/Report.java
+++ b/wrims-ide/src/main/java/gov/ca/water/wrims/gui/ide/reporttool/Report.java
@@ -285,8 +285,8 @@ public class Report {
 				tscAlt=Utils.taf2cfs(tscAlt);
 			}
 			String data_units = tscBase.units;
-			String data_type = tscBase.type;
-			
+			String data_type = Utils.getYAxisLabelType(tscBase);
+
 			if (pathMap.plot) {
 				if (pathMap.report_type.startsWith("average")) {
 					generatePlot(Utils.buildDataArray(tscAlt, tscBase, tw),

--- a/wrims-ide/src/main/java/gov/ca/water/wrims/gui/ide/reporttool/Utils.java
+++ b/wrims-ide/src/main/java/gov/ca/water/wrims/gui/ide/reporttool/Utils.java
@@ -190,6 +190,35 @@ public class Utils {
 		}
 	}
 
+    public static String getYAxisLabelType(TimeSeriesContainer tsc) {
+        String defaultLabel = "VARIABLE VALUE";
+        if (tsc == null) {
+            return defaultLabel;
+        }
+
+        try {
+            String cPart = new DSSPathname(tsc.fullName).getCPart();
+            if (cPart != null) {
+                cPart = cPart.trim();
+                if (!cPart.isEmpty() && !"-".equals(cPart)) {
+                    return cPart;
+                }
+            }
+        } catch (Exception e) {
+            // Ignore malformed or incomplete paths and fall back below.
+        }
+
+        if (tsc.parameter != null && !tsc.parameter.isBlank()) {
+            return tsc.parameter;
+        }
+
+        if (tsc.type != null && !tsc.type.isBlank()) {
+            return tsc.type;
+        }
+
+        return defaultLabel;
+    }
+
 	public static String getExceedancePlotTitle(PathnameMap path_map) {
 		String title = "Exceedance " + path_map.var_name.replace("\"", "");
 		if (path_map.var_category.equalsIgnoreCase("S_Jan")) {


### PR DESCRIPTION
## Description

This PR fixes the y-axis label handling in the WRIMS GUI report tool.

The change updates the report rendering logic so that y-axis labels are displayed correctly in generated report figures. The implementation modifies the report-related code in:

* `Report.java`
* `Utils.java`

The change is limited to report label formatting/rendering behavior.

## Motivation and Context

The previous report output did not correctly display the intended y-axis label in some generated figures. This made the GUI report output less clear for users reviewing plotted report results.

This change improves the readability and correctness of generated report figures by fixing the y-axis label behavior.

## How Has This Been Tested?

Tested manually in the WRIMS GUI report workflow by generating report figures and checking that the y-axis labels are displayed correctly.

Testing environment:

* Local Windows development environment
* WRIMS GUI project branch: `bugfix/gui-report-yaxis-labels`

No automated unit test was added because this change affects GUI/report rendering behavior and was verified through manual report generation.

## Types of changes

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Documentation change
* [ ] New tests (new unit tests, test scenarios, or test case documentation)
* [ ] Triggers regression testing (change affects downstream modules and will require regression testing)
* [ ] Other (include a description)
