### PR TITLE
Fix GUI report y-axis labels

### DIFF
--- a/wrims-ide/src/main/java/gov/ca/water/wrims/gui/ide/reporttool/Report.java
+++ b/wrims-ide/src/main/java/gov/ca/water/wrims/gui/ide/reporttool/Report.java
@@ -540,10 +540,19 @@ public final class Report implements IRunnableWithProgress {
     }
 
     private String getTypeOfReference(DssSeries ref) {
-        if (ref != null) {
-            return firstNonBlank(ref.type, getPathPart(ref.pathname, 3));
+        if (ref == null) {
+            return "";
         }
-        return "";
+
+        String cPart = getPathPart(ref.pathname, 3);
+        if (cPart != null) {
+            cPart = cPart.trim();
+            if (!cPart.isEmpty() && !"-".equals(cPart)) {
+                return cPart;
+            }
+        }
+
+        return firstNonBlank(ref.parameter, ref.type);
     }
 
     private String getType(DssSeries ref1, DssSeries ref2) {
@@ -744,7 +753,7 @@ public final class Report implements IRunnableWithProgress {
                 values[i] = container.values[i];
             }
 
-            return new DssSeries(pathname, nullToBlank(container.units), nullToBlank(container.type), times, values);
+            return new DssSeries(pathname, nullToBlank(container.units), nullToBlank(container.parameter), nullToBlank(container.type), times, values);
         } catch (RuntimeException e) {
             throw e;
         } catch (Exception e) {
@@ -792,7 +801,7 @@ public final class Report implements IRunnableWithProgress {
             }
         }
 
-        return new DssSeries(data.pathname, data.units, data.type, toLongArray(times), toDoubleArray(values));
+        return new DssSeries(data.pathname, data.units, data.parameter, data.type, toLongArray(times), toDoubleArray(values));
     }
 
     private String createPathFromVarname(String path, String varname) {
@@ -946,10 +955,11 @@ public final class Report implements IRunnableWithProgress {
     }
 
     @SuppressWarnings("java:S6218")
-    private record DssSeries(String pathname, String units, String type, long[] times, double[] values) {
+    private record DssSeries(String pathname, String units, String parameter, String type, long[] times,
+          double[] values) {
 
         private DssSeries withValues(double[] newValues, String newUnits) {
-            return new DssSeries(pathname, newUnits, type, Arrays.copyOf(times, times.length), newValues);
+            return new DssSeries(pathname, newUnits, parameter, type, Arrays.copyOf(times, times.length), newValues);
         }
 
         private DssSeries add(DssSeries other) {
@@ -965,7 +975,7 @@ public final class Report implements IRunnableWithProgress {
                 }
             }
 
-            return new DssSeries(pathname, units, type, newTimes, newValues);
+            return new DssSeries(pathname, units, parameter, type, newTimes, newValues);
         }
     }
 }


### PR DESCRIPTION
## Description

This PR updates GUI report y-axis label generation in `Report.java`.

Previously, the report y-axis label type preferred the DSS time-series `type` field before the DSS pathname C Part. This could cause GUI-generated report labels such as:

* `PER-CUM(TAF)`
* `PER-AVER(CFS)`
* `INST-VAL(CFS)`

These values describe DSS interval/type metadata rather than the semantic variable represented by the DSS pathname.

This change updates the y-axis label type resolution priority to:

1. DSS pathname C Part
2. `TimeSeriesContainer.parameter`
3. `TimeSeriesContainer.type`

The `DssSeries` record now preserves `parameter` so that it can be used as a fallback between DSS C Part and DSS type.

## Motivation and Context

The GUI report y-axis labels should match the expected EPPT / CalLite report behavior.

For DSS paths, the C Part usually represents the semantic variable name, such as:

* `STORAGE`
* `CHANNEL`
* `DIVERSION`
* `SALINITY`

The previous implementation could still display DSS type metadata such as `PER-CUM`, `PER-AVER`, or `INST-VAL` as the y-axis label. This made the GUI-generated report labels less consistent with expected EPPT / CalLite report output.

This PR fixes that by preferring the DSS pathname C Part when generating y-axis labels.

## How Has This Been Tested?

Tested by reviewing the report-generation flow in `Report.java` and verifying that the y-axis label type is now resolved using the expected priority:

```text
DSS C Part -> parameter -> type
```

The change is limited to `Report.java`.

The following behavior was checked:

* `getTypeOfReference()` now prefers the DSS pathname C Part.
* `TimeSeriesContainer.parameter` is preserved in `DssSeries`.
* Unit conversion methods such as `cfs2taf()` and `taf2cfs()` preserve `parameter`.
* Time-window slicing preserves `parameter`.
* PDF rendering code in `ReportPDFWriter.java` is unchanged because it only renders the y-axis label passed from `Report.java`.

Gradle build was run locally. The build completed, with only a Gradle configuration cache suggestion shown.

## Screenshots (if appropriate)

Not applicable.

## Types of changes

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Documentation change
* [ ] New tests (new unit tests, test scenarios, or test case documentation)
* [ ] Triggers regression testing (change affects downstream modules and will require regression testing)
* [ ] Other (include a description)
