### PR TITLE
Fix WRIMS debug initialization and JDWP port handling

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ wrims-engine = "3.0.0-alpha.10"
 commons-io = "2.22.0"
 junit_5 = "6.1.0"
 junit_5_platform = "6.1.0"
+mockito = "5.17.0"
 antlr = "3.5.3"
 itext = "2009.09.21"
 jfreechart = "1.5.6"
@@ -64,6 +65,7 @@ junit-5-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "j
 junit-5-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit_5" }
 junit-5-platform-engine = { module = "org.junit.platform:junit-platform-engine", version.ref = "junit_5_platform" }
 junit-5-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit_5_platform" }
+mockito = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 antlr = { module = "org.antlr:antlr", version.ref = "antlr" }
 antlr-runtime = { module = "org.antlr:antlr-runtime", version.ref = "antlr" }
 jfreechart = { module = "org.jfree:jfreechart", version.ref = "jfreechart" }

--- a/wrims-ide/build.gradle
+++ b/wrims-ide/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 
     windows_x64(libs.javaHeclib){artifact {type = 'zip'}}
     testImplementation(libs.bundles.junit5)
+    testImplementation libs.mockito
 
     // GraalPy
     runtimeOnly(libs.bundles.graalvm.runtime)

--- a/wrims-ide/src/main/java/gov/ca/water/wrims/gui/ide/debugger/launcher/WPPLaunchDelegate.java
+++ b/wrims-ide/src/main/java/gov/ca/water/wrims/gui/ide/debugger/launcher/WPPLaunchDelegate.java
@@ -179,25 +179,7 @@ public class WPPLaunchDelegate extends LaunchConfigurationDelegate {
 		try {
 			if (mode.equals("debug")){
 				DebugCorePlugin.debugSet.reset();
-				Process process = null;
-				IProcess p = null;
-				boolean targetRegistered = false;
-				try {
-					process = Runtime.getRuntime().exec(WPPSettings.WRIMS_ENGINE_BAT);
-					p = DebugPlugin.newProcess(launch, process, "DebugWPP");
-					try(WPPDebugTarget target = new WPPDebugTarget(launch, p, requestPort, eventPort)) {
-						target.getStart();
-						launch.addDebugTarget(target);
-						targetRegistered = true;
-						process.waitFor();
-						terminateCode = process.exitValue();
-					}
-				} catch (Exception e) {
-					if (!targetRegistered) {
-						cleanupStartedDebugProcess(p, process);
-					}
-					throw e;
-				}
+				terminateCode = runDebugSession(launch, requestPort, eventPort, false);
 			}else{
 				Process process = Runtime.getRuntime().exec(WPPSettings.WRIMS_ENGINE_BAT);
 				IProcess p = DebugPlugin.newProcess(launch, process, "RunWPP");
@@ -208,8 +190,35 @@ public class WPPLaunchDelegate extends LaunchConfigurationDelegate {
 		} catch (Exception e) {
 			WPPException.handleException(e);
 		}
-		
+
 		return terminateCode;
+	}
+
+	private int runDebugSession(ILaunch launch, int requestPort, int eventPort, boolean removeTargetAfterCompletion) throws Exception {
+		Process process = null;
+		IProcess eclipseProcess = null;
+		boolean targetRegistered = false;
+		try {
+			process = Runtime.getRuntime().exec(WPPSettings.WRIMS_ENGINE_BAT);
+			eclipseProcess = DebugPlugin.newProcess(launch, process, "DebugWPP");
+			try (WPPDebugTarget target = new WPPDebugTarget(launch, eclipseProcess, requestPort, eventPort)) {
+				target.getStart();
+				launch.addDebugTarget(target);
+				targetRegistered = true;
+				process.waitFor();
+				int terminateCode = process.exitValue();
+				if (removeTargetAfterCompletion) {
+					launch.removeDebugTarget(target);
+					process.destroy();
+				}
+				return terminateCode;
+			}
+		} catch (Exception e) {
+			if (!targetRegistered) {
+				cleanupStartedDebugProcess(eclipseProcess, process);
+			}
+			throw e;
+		}
 	}
 	
 	public int paLaunch(ILaunchConfiguration configuration, String mode, ILaunch launch) throws CoreException{
@@ -240,27 +249,7 @@ public class WPPLaunchDelegate extends LaunchConfigurationDelegate {
 			try {
 				if (mode.equals("debug")){
 					DebugCorePlugin.debugSet.reset();
-					Process process = null;
-					IProcess p = null;
-					boolean targetRegistered = false;
-					try {
-						process = Runtime.getRuntime().exec(WPPSettings.WRIMS_ENGINE_BAT);
-						p = DebugPlugin.newProcess(launch, process, "DebugWPP");
-						try(WPPDebugTarget target = new WPPDebugTarget(launch, p, requestPort, eventPort)) {
-							target.getStart();
-							launch.addDebugTarget(target);
-							targetRegistered = true;
-							process.waitFor();
-							terminateCode = process.exitValue();
-							launch.removeDebugTarget(target);
-							process.destroy();
-						}
-					} catch (Exception e) {
-						if (!targetRegistered) {
-							cleanupStartedDebugProcess(p, process);
-						}
-						throw e;
-					}
+					terminateCode = runDebugSession(launch, requestPort, eventPort, true);
 				}else{
 					Process process = Runtime.getRuntime().exec(WPPSettings.WRIMS_ENGINE_BAT);
 					IProcess p = DebugPlugin.newProcess(launch, process, "RunWPP");

--- a/wrims-ide/src/main/java/gov/ca/water/wrims/gui/ide/debugger/launcher/WPPLaunchDelegate.java
+++ b/wrims-ide/src/main/java/gov/ca/water/wrims/gui/ide/debugger/launcher/WPPLaunchDelegate.java
@@ -39,6 +39,7 @@ import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -47,6 +48,7 @@ import org.eclipse.datatools.connectivity.IConnectionProfile;
 import org.eclipse.datatools.connectivity.ProfileManager;
 import org.eclipse.datatools.connectivity.drivers.jdbc.IJDBCConnectionProfileConstants;
 import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.DebugException;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.model.IDebugTarget;
@@ -177,13 +179,24 @@ public class WPPLaunchDelegate extends LaunchConfigurationDelegate {
 		try {
 			if (mode.equals("debug")){
 				DebugCorePlugin.debugSet.reset();
-				Process process = Runtime.getRuntime().exec(WPPSettings.WRIMS_ENGINE_BAT);
-				IProcess p = DebugPlugin.newProcess(launch, process, "DebugWPP");
-				try(WPPDebugTarget target = new WPPDebugTarget(launch, p, requestPort, eventPort)) {
-					target.getStart();
-					launch.addDebugTarget(target);
-					process.waitFor();
-					terminateCode = process.exitValue();
+				Process process = null;
+				IProcess p = null;
+				boolean targetRegistered = false;
+				try {
+					process = Runtime.getRuntime().exec(WPPSettings.WRIMS_ENGINE_BAT);
+					p = DebugPlugin.newProcess(launch, process, "DebugWPP");
+					try(WPPDebugTarget target = new WPPDebugTarget(launch, p, requestPort, eventPort)) {
+						target.getStart();
+						launch.addDebugTarget(target);
+						targetRegistered = true;
+						process.waitFor();
+						terminateCode = process.exitValue();
+					}
+				} catch (Exception e) {
+					if (!targetRegistered) {
+						cleanupStartedDebugProcess(p, process);
+					}
+					throw e;
 				}
 			}else{
 				Process process = Runtime.getRuntime().exec(WPPSettings.WRIMS_ENGINE_BAT);
@@ -227,15 +240,26 @@ public class WPPLaunchDelegate extends LaunchConfigurationDelegate {
 			try {
 				if (mode.equals("debug")){
 					DebugCorePlugin.debugSet.reset();
-					Process process = Runtime.getRuntime().exec(WPPSettings.WRIMS_ENGINE_BAT);
-					IProcess p = DebugPlugin.newProcess(launch, process, "DebugWPP");
-					try(WPPDebugTarget target = new WPPDebugTarget(launch, p, requestPort, eventPort)) {
-						target.getStart();
-						launch.addDebugTarget(target);
-						process.waitFor();
-						terminateCode = process.exitValue();
-						launch.removeDebugTarget(target);
-						process.destroy();
+					Process process = null;
+					IProcess p = null;
+					boolean targetRegistered = false;
+					try {
+						process = Runtime.getRuntime().exec(WPPSettings.WRIMS_ENGINE_BAT);
+						p = DebugPlugin.newProcess(launch, process, "DebugWPP");
+						try(WPPDebugTarget target = new WPPDebugTarget(launch, p, requestPort, eventPort)) {
+							target.getStart();
+							launch.addDebugTarget(target);
+							targetRegistered = true;
+							process.waitFor();
+							terminateCode = process.exitValue();
+							launch.removeDebugTarget(target);
+							process.destroy();
+						}
+					} catch (Exception e) {
+						if (!targetRegistered) {
+							cleanupStartedDebugProcess(p, process);
+						}
+						throw e;
 					}
 				}else{
 					Process process = Runtime.getRuntime().exec(WPPSettings.WRIMS_ENGINE_BAT);
@@ -553,7 +577,7 @@ public class WPPLaunchDelegate extends LaunchConfigurationDelegate {
 		}
 		*/
         String javaPath = EclipseUtil.getJreRelativePath().resolve("bin").resolve("java").toString();
-        String remoteDebugSettings = "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5006";
+        String remoteDebugSettings = getRemoteDebugSettings();
 		if (compileOnly.equalsIgnoreCase("no")){
 			if (mode.equals("debug")){
 				out.println(javaPath +" -Xmx"+DebugCorePlugin.xmx+"m -Xss1024K " + remoteDebugSettings +" -XX:+CreateCoredumpOnCrash -Duser.timezone=Etc/GMT+8 -Djava.library.path=\"" + externalPath + ";lib\" -cp \""+externalPath+";"+"lib\\external;lib\\*\" gov.ca.water.wrims.engine.core.components.DebugInterface "+requestPort+" "+eventPort+" "+"-config="+configFilePath);
@@ -569,7 +593,15 @@ public class WPPLaunchDelegate extends LaunchConfigurationDelegate {
 		}
 		out.close();
 	}
-	
+
+	private String getRemoteDebugSettings() {
+		String jdwpPort = System.getProperty("wrims.jdwp.port", "0").trim();
+		if (jdwpPort.equalsIgnoreCase("off") || jdwpPort.equalsIgnoreCase("false")) {
+			return "";
+		}
+		return "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:" + jdwpPort;
+	}
+
 	public String generateConfigFile(ILaunchConfiguration configuration, String mainFileAbsPath){
 		
 		Map<String, String> configMap = new HashMap<String, String>();
@@ -938,6 +970,28 @@ public class WPPLaunchDelegate extends LaunchConfigurationDelegate {
 	 */
 	private void abort(String message, Throwable e) throws CoreException {
 		throw new CoreException(new Status(IStatus.ERROR, DebugCorePlugin.getDefault().getBundle().getSymbolicName(), 0, message, e));
+	}
+
+	private void cleanupStartedDebugProcess(IProcess eclipseProcess, Process javaProcess) {
+		try {
+			if (eclipseProcess != null && !eclipseProcess.isTerminated()) {
+				eclipseProcess.terminate();
+			}
+		} catch (DebugException e) {
+			WPPException.handleException(e);
+		}
+
+		if (javaProcess != null && javaProcess.isAlive()) {
+			javaProcess.destroy();
+			try {
+				if (!javaProcess.waitFor(5, TimeUnit.SECONDS)) {
+					javaProcess.destroyForcibly();
+				}
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				javaProcess.destroyForcibly();
+			}
+		}
 	}
 	
 	/**

--- a/wrims-ide/src/main/java/gov/ca/water/wrims/gui/ide/debugger/model/WPPDebugTarget.java
+++ b/wrims-ide/src/main/java/gov/ca/water/wrims/gui/ide/debugger/model/WPPDebugTarget.java
@@ -28,6 +28,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
+import java.net.InetSocketAddress;
 import java.lang.reflect.InvocationTargetException;
 import java.net.Socket;
 import java.util.ArrayList;
@@ -115,6 +116,9 @@ public class WPPDebugTarget extends WPPDebugElement
 	private Vector fEventListeners = new Vector();
 	private final CountDownLatch initialized = new CountDownLatch(1);
 	private volatile Exception initializationFailure;
+	private static final int CONNECT_TIMEOUT_MS = 1000;
+	private static final int CONNECT_RETRY_DELAY_MS = 500;
+	private static final int CONNECT_RETRY_LIMIT_MS = 30000;
 
 	/**
 	 * Listens to events from the WPP VM and fires corresponding 
@@ -191,10 +195,8 @@ public class WPPDebugTarget extends WPPDebugElement
 			fLaunch = launch;
 			fProcess = process;
 			addEventListener(this);
-			// give interpreter a chance to start
-			Thread.sleep(3000);
-			fRequestSocket = new Socket("localhost", requestPort);
-			fEventSocket = new Socket("localhost", eventPort);
+			fRequestSocket = connectSocketWithRetry(requestPort);
+			fEventSocket = connectSocketWithRetry(eventPort);
 			fRequestWriter = new PrintWriter(fRequestSocket.getOutputStream());
 			fRequestReader = new BufferedReader(new InputStreamReader(fRequestSocket.getInputStream()));
 			fEventReader = new BufferedReader(new InputStreamReader(fEventSocket.getInputStream()));
@@ -216,6 +218,33 @@ public class WPPDebugTarget extends WPPDebugElement
 		} finally {
 			initialized.countDown();
 		}
+	}
+
+	private Socket connectSocketWithRetry(int port) throws IOException, InterruptedException {
+		long deadline = System.currentTimeMillis() + CONNECT_RETRY_LIMIT_MS;
+		IOException lastException = null;
+
+		while (System.currentTimeMillis() < deadline) {
+			if (fProcess != null && fProcess.isTerminated()) {
+				throw new IOException("WPP VM process terminated before opening port " + port, lastException);
+			}
+
+			Socket socket = new Socket();
+			try {
+				socket.connect(new InetSocketAddress("localhost", port), CONNECT_TIMEOUT_MS);
+				return socket;
+			} catch (IOException e) {
+				lastException = e;
+				try {
+					socket.close();
+				} catch (IOException closeException) {
+					lastException.addSuppressed(closeException);
+				}
+				Thread.sleep(CONNECT_RETRY_DELAY_MS);
+			}
+		}
+
+		throw new IOException("Timed out waiting for WPP VM port " + port, lastException);
 	}
 
 	private boolean awaitInitialized() throws DebugException {
@@ -250,19 +279,21 @@ public class WPPDebugTarget extends WPPDebugElement
 			fRequestReader.close();
 		}
 	}
-	
-	public void getStart() {
-		String data;
-		try {
-			data=sendRequest("start");
-			DebugCorePlugin.isDebugging=true;
-			
-			data=sendRequest("time:"+DebugCorePlugin.debugYear+"/"+DebugCorePlugin.debugMonth+"/"+DebugCorePlugin.debugDay+"/"+DebugCorePlugin.debugCycle);
-			data=sendRequest("conditional_breakpoint:"+DebugCorePlugin.conditionalBreakpoint);
-			enableRunMenuWithStart();
-		} catch (DebugException e) {
-			WPPException.handleException(e);
+
+	public void getStart() throws DebugException {
+		requireResponse("start");
+		requireResponse("time:"+DebugCorePlugin.debugYear+"/"+DebugCorePlugin.debugMonth+"/"+DebugCorePlugin.debugDay+"/"+DebugCorePlugin.debugCycle);
+		requireResponse("conditional_breakpoint:"+DebugCorePlugin.conditionalBreakpoint);
+		DebugCorePlugin.isDebugging=true;
+		enableRunMenuWithStart();
+	}
+
+	private String requireResponse(String request) throws DebugException {
+		String data = sendRequest(request);
+		if (data == null) {
+			requestFailed("No response for startup request: " + request, null);
 		}
+		return data;
 	}
 	
 	public void processViews(){

--- a/wrims-ide/src/test/java/gov/ca/water/wrims/gui/ide/debugger/DebugInitializationTest.java
+++ b/wrims-ide/src/test/java/gov/ca/water/wrims/gui/ide/debugger/DebugInitializationTest.java
@@ -1,0 +1,194 @@
+package gov.ca.water.wrims.gui.ide.debugger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import gov.ca.water.wrims.gui.ide.debugger.core.DebugCorePlugin;
+import gov.ca.water.wrims.gui.ide.debugger.launcher.WPPLaunchDelegate;
+import gov.ca.water.wrims.gui.ide.debugger.model.WPPDebugTarget;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.eclipse.debug.core.DebugException;
+import org.eclipse.debug.core.model.IProcess;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/** Tests debug startup, socket initialization, JDWP configuration, and cleanup. */
+class DebugInitializationTest {
+
+    private final String originalJdwpPort = System.getProperty("wrims.jdwp.port");
+
+    @AfterEach
+    void restoreJdwpPort() {
+        if (originalJdwpPort == null) {
+            System.clearProperty("wrims.jdwp.port");
+        } else {
+            System.setProperty("wrims.jdwp.port", originalJdwpPort);
+        }
+    }
+
+    @Test
+    /** Verifies debug sessions use an automatically allocated JDWP port by default. */
+    void defaultsToDynamicJdwpPort() throws Exception {
+        System.clearProperty("wrims.jdwp.port");
+
+        assertEquals("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:0",
+                remoteDebugSettings());
+    }
+
+    @Test
+    /** Verifies configured JDWP ports are honored and JDWP can be disabled. */
+    void usesConfiguredJdwpPortAndSupportsDisabledValues() throws Exception {
+        System.setProperty("wrims.jdwp.port", " 5006 ");
+        assertEquals("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5006",
+                remoteDebugSettings());
+
+        System.setProperty("wrims.jdwp.port", "off");
+        assertEquals("", remoteDebugSettings());
+
+        System.setProperty("wrims.jdwp.port", "false");
+        assertEquals("", remoteDebugSettings());
+    }
+
+    @Test
+    /** Verifies startup sends each required request before enabling run controls. */
+    void getStartSendsAllStartupRequestsBeforeEnablingRunControls() throws Exception {
+        List<String> requests = new ArrayList<>();
+        TestDebugTarget target = allocate(TestDebugTarget.class);
+        target.requests = requests;
+
+        target.getStart();
+
+        assertEquals(List.of(
+                "start",
+            "time:" + DebugCorePlugin.debugYear + "/"
+                + DebugCorePlugin.debugMonth + "/"
+                + DebugCorePlugin.debugDay + "/"
+                + DebugCorePlugin.debugCycle,
+            "conditional_breakpoint:" + DebugCorePlugin.conditionalBreakpoint), requests);
+        assertTrue(target.controlsEnabled);
+    }
+
+    @Test
+    /** Verifies a missing startup response is propagated as a debug failure. */
+    void getStartFailsWhenStartupRequestHasNoResponse() throws Exception {
+        TestDebugTarget target = allocate(TestDebugTarget.class);
+        target.requests = new ArrayList<>();
+        target.returnNull = true;
+
+        assertThrows(DebugException.class, target::getStart);
+        assertFalse(target.controlsEnabled);
+    }
+
+    @Test
+    /** Verifies an available VM port can be connected to successfully. */
+    void socketConnectionSucceedsWhenPortIsAvailable() throws Exception {
+        try (ServerSocket server = new ServerSocket(0)) {
+            TestDebugTarget target = allocate(TestDebugTarget.class);
+            Method connect = WPPDebugTarget.class.getDeclaredMethod("connectSocketWithRetry", int.class);
+            connect.setAccessible(true);
+
+            try (Socket socket = invokeSocket(connect, target, server.getLocalPort())) {
+                assertTrue(socket.isConnected());
+            }
+        }
+    }
+
+    @Test
+    /** Verifies socket initialization stops when the VM process has already terminated. */
+    void socketConnectionStopsImmediatelyWhenProcessTerminated() throws Exception {
+        TestDebugTarget target = allocate(TestDebugTarget.class);
+        setProcess(target, processProxy(true));
+        Method connect = WPPDebugTarget.class.getDeclaredMethod("connectSocketWithRetry", int.class);
+        connect.setAccessible(true);
+
+        InvocationTargetException failure = assertThrows(InvocationTargetException.class,
+                () -> connect.invoke(target, 1));
+        assertTrue(failure.getCause() instanceof IOException);
+        assertTrue(failure.getCause().getMessage().contains("terminated before opening port 1"));
+    }
+
+    @Test
+    /** Verifies a process started for debugging is cleaned up after initialization fails. */
+    void cleanupTerminatesStartedJavaProcess() throws Exception {
+        Process process = new ProcessBuilder(javaBinary(), "-version").start();
+        Method cleanup = WPPLaunchDelegate.class.getDeclaredMethod("cleanupStartedDebugProcess", IProcess.class,
+                Process.class);
+        cleanup.setAccessible(true);
+
+        cleanup.invoke(new WPPLaunchDelegate(), null, process);
+
+        assertTrue(process.waitFor(1, java.util.concurrent.TimeUnit.SECONDS));
+    }
+
+    private static String remoteDebugSettings() throws Exception {
+        Method method = WPPLaunchDelegate.class.getDeclaredMethod("getRemoteDebugSettings");
+        method.setAccessible(true);
+        return (String) method.invoke(new WPPLaunchDelegate());
+    }
+
+    private static Socket invokeSocket(Method method, WPPDebugTarget target, int port) throws Exception {
+        return (Socket) method.invoke(target, port);
+    }
+
+    private static void setProcess(WPPDebugTarget target, IProcess process) throws Exception {
+        java.lang.reflect.Field field = WPPDebugTarget.class.getDeclaredField("fProcess");
+        field.setAccessible(true);
+        field.set(target, process);
+    }
+
+    private static IProcess processProxy(boolean terminated) {
+        AtomicBoolean isTerminated = new AtomicBoolean(terminated);
+        return (IProcess) Proxy.newProxyInstance(IProcess.class.getClassLoader(), new Class<?>[] {IProcess.class},
+                (proxy, method, args) -> {
+                    if (method.getName().equals("isTerminated")) {
+                        return isTerminated.get();
+                    }
+                    if (method.getReturnType() == boolean.class) {
+                        return false;
+                    }
+                    return null;
+                });
+    }
+
+    private static String javaBinary() {
+        return java.nio.file.Path.of(System.getProperty("java.home"), "bin", "java.exe").toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T allocate(Class<T> type) throws Exception {
+        java.lang.reflect.Field field = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
+        field.setAccessible(true);
+        return (T) ((sun.misc.Unsafe) field.get(null)).allocateInstance(type);
+    }
+
+    private static class TestDebugTarget extends WPPDebugTarget {
+        private List<String> requests = new ArrayList<>();
+        private boolean returnNull;
+        private boolean controlsEnabled;
+
+        TestDebugTarget() throws Exception {
+            super(null, null, 0, 0);
+        }
+
+        @Override
+        public String sendRequest(String request) throws DebugException {
+            requests.add(request);
+            return returnNull ? null : "ok";
+        }
+
+        @Override
+        public void enableRunMenuWithStart() {
+            controlsEnabled = true;
+        }
+    }
+}

--- a/wrims-ide/src/test/java/gov/ca/water/wrims/gui/ide/debugger/DebugInitializationTest.java
+++ b/wrims-ide/src/test/java/gov/ca/water/wrims/gui/ide/debugger/DebugInitializationTest.java
@@ -18,9 +18,24 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.eclipse.debug.core.DebugException;
+import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.model.IProcess;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 /** Tests debug startup, socket initialization, JDWP configuration, and cleanup. */
 class DebugInitializationTest {
@@ -129,6 +144,100 @@ class DebugInitializationTest {
 
         assertTrue(process.waitFor(1, java.util.concurrent.TimeUnit.SECONDS));
     }
+
+    @Test
+    /** Verifies a registered debug target is retained for a regular debug session. */
+    void runDebugSessionRegistersTargetAndReturnsProcessExitCode() throws Exception {
+        Method runDebugSession = WPPLaunchDelegate.class.getDeclaredMethod("runDebugSession", ILaunch.class,
+                int.class, int.class, boolean.class);
+        runDebugSession.setAccessible(true);
+        ILaunch launch = mock(ILaunch.class);
+        Runtime runtime = mock(Runtime.class);
+        Process process = mock(Process.class);
+        IProcess eclipseProcess = mock(IProcess.class);
+        when(runtime.exec("WRIMSv3_Engine.bat")).thenReturn(process);
+        when(process.exitValue()).thenReturn(17);
+
+        try (MockedStatic<Runtime> runtimeMock = mockStatic(Runtime.class);
+            MockedStatic<DebugPlugin> debugPluginMock = mockStatic(DebugPlugin.class);
+            MockedConstruction<WPPDebugTarget> targetMock = mockConstruction(WPPDebugTarget.class)) {
+            runtimeMock.when(Runtime::getRuntime).thenReturn(runtime);
+            debugPluginMock.when(() -> DebugPlugin.newProcess(launch, process, "DebugWPP"))
+                .thenReturn(eclipseProcess);
+
+            int exitCode = invokeRunDebugSession(runDebugSession, launch, false);
+
+            assertEquals(17, exitCode);
+            verify(launch).addDebugTarget(targetMock.constructed().get(0));
+            verify(launch, org.mockito.Mockito.never()).removeDebugTarget(any());
+            verify(process).waitFor();
+        }
+    }
+
+    @Test
+    /** Verifies completed sessions remove their target and destroy the engine process. */
+    void runDebugSessionRemovesTargetWhenRequested() throws Exception {
+        Method runDebugSession = WPPLaunchDelegate.class.getDeclaredMethod("runDebugSession", ILaunch.class,
+            int.class, int.class, boolean.class);
+        runDebugSession.setAccessible(true);
+        ILaunch launch = mock(ILaunch.class);
+        Runtime runtime = mock(Runtime.class);
+        Process process = mock(Process.class);
+        IProcess eclipseProcess = mock(IProcess.class);
+        when(runtime.exec("WRIMSv3_Engine.bat")).thenReturn(process);
+        when(process.exitValue()).thenReturn(0);
+
+        try (MockedStatic<Runtime> runtimeMock = mockStatic(Runtime.class);
+            MockedStatic<DebugPlugin> debugPluginMock = mockStatic(DebugPlugin.class);
+            MockedConstruction<WPPDebugTarget> targetMock = mockConstruction(WPPDebugTarget.class)) {
+            runtimeMock.when(Runtime::getRuntime).thenReturn(runtime);
+            debugPluginMock.when(() -> DebugPlugin.newProcess(launch, process, "DebugWPP"))
+                .thenReturn(eclipseProcess);
+
+            assertEquals(0, invokeRunDebugSession(runDebugSession, launch, true));
+
+            verify(launch).removeDebugTarget(targetMock.constructed().get(0));
+            verify(process).destroy();
+        }
+    }
+
+    @Test
+    /** Verifies initialization failure cleans up an unregistered debug process. */
+    void runDebugSessionCleansUpWhenTargetInitializationFails() throws Exception {
+        Method runDebugSession = WPPLaunchDelegate.class.getDeclaredMethod("runDebugSession", ILaunch.class,
+            int.class, int.class, boolean.class);
+        runDebugSession.setAccessible(true);
+        ILaunch launch = mock(ILaunch.class);
+        Runtime runtime = mock(Runtime.class);
+        Process process = mock(Process.class);
+        IProcess eclipseProcess = mock(IProcess.class);
+        when(runtime.exec("WRIMSv3_Engine.bat")).thenReturn(process);
+        when(process.isAlive()).thenReturn(true);
+        when(process.waitFor(5, java.util.concurrent.TimeUnit.SECONDS)).thenReturn(true);
+        when(eclipseProcess.isTerminated()).thenReturn(false);
+
+        try (MockedStatic<Runtime> runtimeMock = mockStatic(Runtime.class);
+            MockedStatic<DebugPlugin> debugPluginMock = mockStatic(DebugPlugin.class);
+            MockedConstruction<WPPDebugTarget> targetMock = mockConstruction(WPPDebugTarget.class,
+                (target, context) -> doThrow(new DebugException(
+                    new Status(IStatus.ERROR, "test", "startup failed"))).when(target).getStart())) {
+            runtimeMock.when(Runtime::getRuntime).thenReturn(runtime);
+            debugPluginMock.when(() -> DebugPlugin.newProcess(launch, process, "DebugWPP"))
+                .thenReturn(eclipseProcess);
+
+            InvocationTargetException failure = assertThrows(InvocationTargetException.class,
+                () -> invokeRunDebugSession(runDebugSession, launch, false));
+
+            assertTrue(failure.getCause() instanceof DebugException);
+            verify(eclipseProcess).terminate();
+            verify(process).destroy();
+            verifyNoInteractions(launch);
+        }
+    }
+
+        private static int invokeRunDebugSession(Method method, ILaunch launch, boolean removeTarget) throws Exception {
+        return (int) method.invoke(new WPPLaunchDelegate(), launch, 1, 2, removeTarget);
+        }
 
     private static String remoteDebugSettings() throws Exception {
         Method method = WPPLaunchDelegate.class.getDeclaredMethod("getRemoteDebugSettings");


### PR DESCRIPTION
## Notes for Reviewers

Please review the debug startup failure handling, process cleanup behavior, socket retry logic, and JDWP configuration.

## Description

This PR updates the WRIMS debug initialization flow to:

- Clean up the Java DebugInterface process when initialization fails before target registration.
- Propagate startup request failures instead of silently continuing.
- Retry request and event socket connections for up to 30 seconds.
- Use dynamic JDWP port allocation by default through `address=*:0`.
- Support overriding or disabling JDWP with the `wrims.jdwp.port` system property.

Only the following source files are changed:

- `WPPLaunchDelegate.java`
- `WPPDebugTarget.java`

## Motivation and Context

WRIMS Debug could intermittently fail with `Unable to connect to WPP VM` or JDWP `Address already in use` errors.

Failed initialization could leave a Java process running and occupying port `5006`. The previous fixed three-second socket delay could also fail when the DebugInterface started slowly.

These changes make startup failures explicit, clean up partially initialized processes, and remove the default dependency on port `5006`.

## How Has This Been Tested?

Tested with:

- `./gradlew.bat :wrims-ide:jar`
- Repeated WRIMS Debug/Stop/Debug cycles
- Verification that failed launches do not leave stale Java processes
- Verification that the generated engine batch file uses `address=*:0`

Build and test completed successfully.

## Screenshots

Not applicable.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change
- [ ] New tests (new unit tests, test scenarios, or test case documentation)
- [ ] Triggers regression testing (change affects downstream modules and will require regression testing)
- [ ] Other